### PR TITLE
fixing comments on pipelines to reflect Lookup

### DIFF
--- a/default/pipelines/pan_config/conf.yml
+++ b/default/pipelines/pan_config/conf.yml
@@ -14,9 +14,9 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_decryption/conf.yml
+++ b/default/pipelines/pan_decryption/conf.yml
@@ -14,9 +14,9 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_globalprotect/conf.yml
+++ b/default/pipelines/pan_globalprotect/conf.yml
@@ -14,9 +14,9 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_hipmatch/conf.yml
+++ b/default/pipelines/pan_hipmatch/conf.yml
@@ -15,9 +15,9 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_system/conf.yml
+++ b/default/pipelines/pan_system/conf.yml
@@ -18,11 +18,11 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
 
-        #5-6. Suppress duplicate system event messages
+        #6-7. Suppress duplicate system event messages
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_threat/conf.yml
+++ b/default/pipelines/pan_threat/conf.yml
@@ -14,9 +14,9 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_traffic/conf.yml
+++ b/default/pipelines/pan_traffic/conf.yml
@@ -23,13 +23,13 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
 
-        #6-7. Sample events
+        #6-8. Sample events
 
-        #9. Drop logs with subtype of start
+        #9-11. Drop logs with subtype of start
   - id: eval
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_userid/conf.yml
+++ b/default/pipelines/pan_userid/conf.yml
@@ -14,9 +14,9 @@ functions:
 
         #2. Simple eval to set the host, sourcetype, source, index, and cleanup the _raw message to remove the syslog header
 
-        #3. Use the Auto Timestamp function to set the event timestamp to the "generated time"
+        #3-4. Use the Auto Timestamp function to set the event timestamp to the "generated time"
 
-        #4. Reshape the events using the parser to remove unnecessary fields
+        #5. Reshape the events using the parser to remove unnecessary fields
   - id: eval
     filter: "true"
     disabled: null


### PR DESCRIPTION
New `Lookup` function was added at #3 for all pipelines. Comments at head of pipelines did not reflect this and could be confusing. 

Numbers in comments should now reflect the addition of said `Lookup` function.