### PR TITLE
Multiple Fixes for consistency and broken pipelines

### DIFF
--- a/default/pipelines/pan_config/conf.yml
+++ b/default/pipelines/pan_config/conf.yml
@@ -32,14 +32,14 @@ functions:
         - name: host
           value: _raw.match(/[A-Z][a-z]{2}\s{1,2}\d{1,2}\s\d{2}:\d{2}:\d{2}\s([^\s]+)\s/)[1]
             || host
+        - value: (message || _raw).substring((message || _raw).indexOf(','))
+          name: _raw
         - value: "'pan:config'"
           name: sourcetype
         - name: source
           value: source || C.vars.pan_default_source
         - value: index || C.vars.pan_default_index
           name: index
-        - value: (message || _raw).substring((message || _raw).indexOf(','))
-          name: _raw
       keep:
         - _raw
         - _time
@@ -90,8 +90,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -108,8 +108,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_correlation/conf.yml
+++ b/default/pipelines/pan_correlation/conf.yml
@@ -85,8 +85,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -103,8 +103,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null
@@ -112,8 +112,8 @@ functions:
       srcField: generated_time
       dstField: _time
       defaultTimezone: utc
-      timeExpression: "__tz ? (time.getTime() / 1000) + (__tz * 3600) : (time.getTime() /
-        1000)"
+      timeExpression: "__tz ? (time.getTime() / 1000) + (__tz * 3600) :
+        (time.getTime() / 1000)"
       offset: 0
       maxLen: 150
       defaultTime: now

--- a/default/pipelines/pan_decryption/conf.yml
+++ b/default/pipelines/pan_decryption/conf.yml
@@ -32,14 +32,14 @@ functions:
         - name: host
           value: _raw.match(/[A-Z][a-z]{2}\s{1,2}\d{1,2}\s\d{2}:\d{2}:\d{2}\s([^\s]+)\s/)[1]
             || host
+        - name: _raw
+          value: (message || _raw).substring((message || _raw).indexOf(','))
         - name: sourcetype
           value: "'pan:decryption'"
         - name: source
           value: source || C.vars.pan_default_source
         - name: index
           value: index || C.vars.pan_default_index
-        - name: _raw
-          value: (message || _raw).substring((message || _raw).indexOf(','))
       keep:
         - _raw
         - _time
@@ -86,7 +86,7 @@ functions:
         - src_translated_port
         - dest_translated_port
         - flags
-        - IP_PROTOCOL
+        - ip_protocol
         - action
         - tunnel_id
         - future_use2
@@ -112,8 +112,8 @@ functions:
         - cert_end_time
         - cert_version
         - cert_size
-        - cn_lenght
-        - issure_cn_length
+        - cn_length
+        - issuer_cn_length
         - root_cn_length
         - sni_length
         - cert_flags
@@ -153,7 +153,7 @@ functions:
         - devicegroup_level3
         - devicegroup_level4
         - vsys_name
-        - device_name
+        - dvc_name
         - vsys_id
         - app_subcategory
         - app_category
@@ -161,6 +161,7 @@ functions:
         - app_risk
         - app_characteristic
         - app_container
+        - app_tunneled
         - app_saas
         - app_sanctioned
   - id: eval
@@ -170,8 +171,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -188,8 +189,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null
@@ -267,7 +268,7 @@ functions:
         - src_translated_port
         - dest_translated_port
         - flags
-        - IP_PROTOCOL
+        - ip_protocol
         - action
         - tunnel_id
         - future_use2
@@ -293,8 +294,8 @@ functions:
         - cert_end_time
         - cert_version
         - cert_size
-        - cn_lenght
-        - issure_cn_length
+        - cn_length
+        - issuer_cn_length
         - root_cn_length
         - sni_length
         - cert_flags
@@ -329,6 +330,22 @@ functions:
         - dest_mac
         - sequence_number
         - action_flags
+        - devicegroup_level1
+        - devicegroup_level2
+        - devicegroup_level3
+        - devicegroup_level4
+        - vsys_name
+        - dvc_name
+        - vsys_id
+        - app_subcategory
+        - app_category
+        - app_technology
+        - app_risk
+        - app_characteristic
+        - app_container
+        - app_tunneled
+        - app_saas
+        - app_sanction
     description: Serialize PAN OS events to the fields used in the Splunk TA
     groupId: yicqwn
   - id: eval

--- a/default/pipelines/pan_globalprotect/conf.yml
+++ b/default/pipelines/pan_globalprotect/conf.yml
@@ -32,14 +32,14 @@ functions:
         - name: host
           value: _raw.match(/[A-Z][a-z]{2}\s{1,2}\d{1,2}\s\d{2}:\d{2}:\d{2}\s([^\s]+)\s/)[1]
             || host
+        - name: _raw
+          value: (message || _raw).substring((message || _raw).indexOf(','))
         - value: "'pan:globalprotect'"
           name: sourcetype
         - name: source
           value: source || C.vars.pan_default_source
         - name: index
           value: index || C.vars.pan_default_index
-        - name: _raw
-          value: (message || _raw).substring((message || _raw).indexOf(','))
       keep:
         - _raw
         - _time
@@ -113,8 +113,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -131,8 +131,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_hipmatch/conf.yml
+++ b/default/pipelines/pan_hipmatch/conf.yml
@@ -33,14 +33,14 @@ functions:
         - name: host
           value: _raw.match(/[A-Z][a-z]{2}\s{1,2}\d{1,2}\s\d{2}:\d{2}:\d{2}\s([^\s]+)\s/)[1]
             || host
+        - name: _raw
+          value: (message || _raw).substring((message || _raw).indexOf(','))
         - name: sourcetype
           value: "'pan:hipmatch'"
         - name: source
           value: source || C.vars.pan_default_source
         - name: index
           value: index || C.vars.pan_default_index
-        - name: _raw
-          value: (message || _raw).substring((message || _raw).indexOf(','))
       keep:
         - _raw
         - _time
@@ -96,8 +96,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -114,8 +114,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_system/conf.yml
+++ b/default/pipelines/pan_system/conf.yml
@@ -55,8 +55,8 @@ functions:
         - _time
       remove:
         - "*"
-    description: Set fields to correct values and remove the remainder. Cleanup the _raw
-      field by removing the syslog header.
+    description: Set fields to correct values and remove the remainder. Cleanup the
+      _raw field by removing the syslog header.
   - id: serde
     filter: "true"
     disabled: false
@@ -98,8 +98,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -116,8 +116,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null

--- a/default/pipelines/pan_threat/conf.yml
+++ b/default/pipelines/pan_threat/conf.yml
@@ -87,7 +87,7 @@ functions:
         - src_translated_port
         - dest_translated_port
         - session_flags
-        - transport
+        - ip_protocol
         - action
         - misc
         - threat
@@ -165,7 +165,7 @@ functions:
         - src_dag
         - dest_dag
         - partial_hash
-        - high_res_timestmp
+        - high_res_timestamp
         - reason
         - justification
         - nssai_sst
@@ -175,9 +175,9 @@ functions:
         - app_risk
         - app_characteristic
         - app_container
+        - app_tunneled
         - app_saas
         - app_sanction
-        - app_tunneled
         - cloud_report_id
       keep: []
       remove: []
@@ -188,8 +188,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -206,8 +206,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null
@@ -276,7 +276,7 @@ functions:
         - dvc_serial_number
         - "*_dag"
         - partial_hash
-        - high_res_timestmp
+        - high_res_timestamp
         - reason
         - justification
         - nssai_sst
@@ -322,7 +322,7 @@ functions:
         - src_translated_port
         - dest_translated_port
         - session_flags
-        - transport
+        - ip_protocol
         - action
         - misc
         - threat
@@ -365,6 +365,55 @@ functions:
         - threat_category
         - content_version
         - future_use6
+        - sctp_assoc_id
+        - payload_protocol_id
+        - http_headers
+        - url_category_list
+        - rule_uuid
+        - http2_connection
+        - dynusergroup_name
+        - xff_ip
+        - src_dvc_category
+        - src_dvc_profile
+        - src_dvc_model
+        - src_dvc_vendor
+        - src_dvc_os_family
+        - src_dvc_os_version
+        - src_dvc_host
+        - src_dvc_mac
+        - dest_dvc_cateogry
+        - dest_dvc_profile
+        - dest_dvc_model
+        - dest_dvc_vendor
+        - dest_dvc_os_family
+        - dest_dvc_os_version
+        - dest_dvc_host
+        - dest_dvc_mac
+        - container_id
+        - pod_namespace
+        - pod_name
+        - src_edl
+        - dest_edl
+        - host_id
+        - dvc_serial_number
+        - domain_edl
+        - src_dag
+        - dest_dag
+        - partial_hash
+        - high_res_timestamp
+        - reason
+        - justification
+        - nssai_sst
+        - app_subcategory
+        - app_category
+        - app_technology
+        - app_risk
+        - app_characteristic
+        - app_container
+        - app_tunneled
+        - app_saas
+        - app_sanction
+        - cloud_report_id
     groupId: ZHU77H
     description: Push event back into CSV format in _raw
   - id: eval

--- a/default/pipelines/pan_traffic/conf.yml
+++ b/default/pipelines/pan_traffic/conf.yml
@@ -62,8 +62,8 @@ functions:
         - sourcetype
       remove:
         - "*"
-    description: Set fields to correct values and remove the remainder. Cleanup the _raw
-      field by removing the syslog header.
+    description: Set fields to correct values and remove the remainder. Cleanup the
+      _raw field by removing the syslog header.
   - id: serde
     filter: "true"
     disabled: false
@@ -101,7 +101,7 @@ functions:
         - src_translated_port
         - dest_translated_port
         - session_flags
-        - transport
+        - ip_protocol
         - action
         - bytes
         - bytes_out
@@ -197,8 +197,8 @@ functions:
       add:
         - name: host
           value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -215,8 +215,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: false
@@ -300,7 +300,8 @@ functions:
     conf:
       remove:
         - future_use*
-        - "*_time"
+        - generated_time
+        - receive_time
         - sctp_*
         - rule_uuid
         - http2_connection
@@ -322,6 +323,7 @@ functions:
         - nsdsai_*
         - app_*
         - offloaded
+        - tunnel_start_time
       keep:
         - _time
     groupId: yicqwn
@@ -362,7 +364,7 @@ functions:
         - src_translated_port
         - dest_translated_port
         - session_flags
-        - transport
+        - ip_protocol
         - action
         - bytes
         - bytes_out
@@ -394,6 +396,59 @@ functions:
         - tunnel_session_id
         - tunnel_start_time
         - tunnel_type
+        - sctp_assoc_id
+        - sctp_chunks
+        - sctp_chunks_sent
+        - sctp_chunks_received
+        - rule_uuid
+        - http2_connection
+        - link_change_count
+        - policy_id
+        - link_switches
+        - sdwan_cluster
+        - sdwan_device_type
+        - sdwant_cluster_type
+        - sdwan_site
+        - dynusergroup_name
+        - xff_ip
+        - src_dvc_category
+        - src_dvc_model
+        - src_dvc_vendor
+        - src_dvc_os_family
+        - src_dvc_os_version
+        - src_dvc_host
+        - src_dvc_mac
+        - dest_dvc_category
+        - dest_dvc_profile
+        - dest_dvc_model
+        - dest_dvc_vendor
+        - dest_dvc_os_family
+        - dest_dvc_os_version
+        - dest_dvc_host
+        - dest_dvc_mac
+        - container_id
+        - pod_namespace
+        - pod_name
+        - src_edl
+        - dest_edl
+        - host_id
+        - dvc_serial_number
+        - src_dag
+        - dest_dag
+        - session_owner
+        - high_res_timestamp
+        - nsdsadi_sst
+        - nsdsadi_sd
+        - app_subcategory
+        - app_category
+        - app_technology
+        - app_risk
+        - app_characteristic
+        - app_container
+        - app_tunneled
+        - app_saas
+        - app_sanction
+        - offloaded
     description: Serialize PAN OS events to the fields used in the Splunk TA
     groupId: yicqwn
   - id: eval

--- a/default/pipelines/pan_userid/conf.yml
+++ b/default/pipelines/pan_userid/conf.yml
@@ -32,14 +32,14 @@ functions:
         - value: _raw.match(/[A-Z][a-z]{2}\s{1,2}\d{1,2}\s\d{2}:\d{2}:\d{2}\s([^\s]+)\s/)[1]
             || host
           name: host
+        - name: _raw
+          value: (message || _raw).substring((message || _raw).indexOf(','))
         - name: sourcetype
           value: "'pan:userid'"
         - name: source
           value: source || C.vars.pan_default_source
         - name: index
           value: index || C.vars.pan_default_index
-        - name: _raw
-          value: (message || _raw).substring((message || _raw).indexOf(','))
       keep:
         - _raw
         - _time
@@ -66,14 +66,15 @@ functions:
         - generated_time
         - vsys
         - src_ip
-        - source_name
+        - user
+        - datasource_name
         - event_id
         - repeat_count
         - timeout_threshold
         - src_port
         - dest_port
-        - source
-        - source_type
+        - datasource
+        - datasource_type
         - sequence_number
         - action_flags
         - devicegroup_level1
@@ -86,8 +87,6 @@ functions:
         - factor_type
         - factor_completion_time
         - factor_number
-        - future_use2
-        - future_use3
         - ugflags
         - userbysource
         - high_res_timestamp
@@ -97,9 +96,9 @@ functions:
     conf:
       add:
         - name: host
-          value: dvc_name || host
-    description: If Global Variable is true, set the host field value to the value from the
-      dvc_name field
+          value: " dvc_name || host"
+    description: If Global Variable is true, set the host field value to the value
+      from the dvc_name field
   - id: lookup
     filter: "true"
     disabled: null
@@ -116,8 +115,8 @@ functions:
       outFields:
         - lookupField: tz
           eventField: __tz
-    description: Add time zone offset as an internal field to the event. Uses the host
-      field to look up the value from device_info.csv file.
+    description: Add time zone offset as an internal field to the event. Uses the
+      host field to look up the value from device_info.csv file.
   - id: auto_timestamp
     filter: "true"
     disabled: null
@@ -175,14 +174,15 @@ functions:
         - generated_time
         - vsys
         - src_ip
-        - source_name
+        - user
+        - datasource_name
         - event_id
         - repeat_count
         - timeout_threshold
         - src_port
         - dest_port
-        - source
-        - source_type
+        - datasource
+        - datasource_type
         - sequence_number
         - action_flags
         - devicegroup_level1
@@ -195,8 +195,6 @@ functions:
         - factor_type
         - factor_completion_time
         - factor_number
-        - future_use2
-        - future_use3
         - ugflags
         - userbysource
         - high_res_timestamp

--- a/default/pipelines/route.yml
+++ b/default/pipelines/route.yml
@@ -79,7 +79,7 @@ routes:
     disabled: false
     pipeline: pan_correlation
     description: ""
-    clones: [ ]
+    clones: []
     enableOutputExpression: false
     outputExpression: null
     filter: _raw.indexOf(",CORRELATION,") > -1


### PR DESCRIPTION
+ (*/conf.yml) descriptions and other strings were reformatted on export automatically
+ (pan_decryption/conf.yml) renamed fields, fixed typos in names, added missing field(s) in the parse and re-serialize
+ (pan_threat/conf.yml) renamed fields, fixed typos in names, reordered fields, added missing field(s) in the parse and re-serialize
+ (pan_traffic/conf.yml) renamed fields, fixed typos in names, reordered fields, added missing field(s) in the parse and re-serialize
+ (pan_traffic/conf.yml) modified to allow start_time to be logged
+ (pan_userid/conf.yml) fixed missing field, removed extraneous fields, renamed fields for consistency
+ (route.yml) auto reformat on export